### PR TITLE
Allow different color for failed builds

### DIFF
--- a/step.go
+++ b/step.go
@@ -81,6 +81,10 @@ func main() {
 	if errorMessage == "" {
 		markdownlog.SectionToOutput("$HIPCHAT_ERROR_MESSAGE is not provided!")
 	}
+	errorMessageColor := os.Getenv("HIPCHAT_ERROR_MESSAGE_COLOR")
+	if errorMessageColor == "" {
+		markdownlog.SectionToOutput("$HIPCHAT_ERROR_MESSAGE_COLOR is not provided, use default!")
+	}
 
 	isBuildFailedMode := (os.Getenv("STEPLIB_BUILD_STATUS") != "0")
 	if isBuildFailedMode {
@@ -93,6 +97,11 @@ func main() {
 			fmt.Errorf("Build failed, but no HIPCHAT_ERROR_MESSAGE defined, use default")
 		} else {
 			message = errorMessage
+		}
+		if errorMessageColor == "" {
+			fmt.Errorf("Build failed, but no HIPCHAT_ERROR_MESSAGE_COLOR defined, use default")
+		} else {
+			messageColor = errorMessageColor
 		}
 	}
 
@@ -110,7 +119,7 @@ func main() {
 
 	request, err := http.NewRequest("POST", url, &valuesReader)
 	if err != nil {
-		fmt.Println("Failed to create requestuest:", err)
+		fmt.Println("Failed to create request:", err)
 		os.Exit(1)
 	}
 

--- a/step.yml
+++ b/step.yml
@@ -75,4 +75,20 @@ inputs:
     value: yellow
     is_expand: false
     is_required: false
+  - 
+    mapped_to: HIPCHAT_ERROR_MESSAGE_COLOR
+    title: "Message Color - if the build failed"
+    description: |
+      **This option will be used if the build failed.** If you
+      leave this option empty then the default one will be used.
+    value_options:
+      - yellow
+      - red
+      - green
+      - purple
+      - gray
+      - random
+    value: red
+    is_expand: false
+    is_required: false
 


### PR DESCRIPTION
It is often convenient to have one color for success (e.g., green) and a
different one for failure, to draw one's attention (e.g., red).

I also fixed a typo in one of the error messages.