### PR TITLE
Step option to set Message Format and use that in notification API call

### DIFF
--- a/step.go
+++ b/step.go
@@ -31,6 +31,7 @@ func successMessageToOutput(from, roomId, msg string) error {
 	message = message + from + "\n"
 	message = message + "To Romm:\n"
 	message = message + roomId + "\n"
+	message = message + messageFormat + "\n"
 	message = message + "Message:\n"
 	message = message + msg
 

--- a/step.go
+++ b/step.go
@@ -68,6 +68,11 @@ func main() {
 		os.Exit(1)
 	}
 	//optional inputs
+	messageFormat := os.Getenv("message_format")
+	if messageFormat == "" {
+		markdownlog.SectionToOutput("$message_format is not provided, use default - html!")
+		messageFormat = "html"
+	}
 	messageColor := os.Getenv("color")
 	if messageColor == "" {
 		markdownlog.SectionToOutput("$color is not provided, use default!")
@@ -80,6 +85,11 @@ func main() {
 	errorMessage := os.Getenv("message_on_error")
 	if errorMessage == "" {
 		markdownlog.SectionToOutput("$message_on_error is not provided!")
+	}
+	errorMessageFormat := os.Getenv("message_on_error_format")
+	if errorMessageFormat == "" {
+		markdownlog.SectionToOutput("$message_on_error_format is not provided, use default - html!")
+		errorMessageFormat = "html"
 	}
 	errorMessageColor := os.Getenv("color_on_error")
 	if errorMessageColor == "" {
@@ -98,6 +108,11 @@ func main() {
 		} else {
 			message = errorMessage
 		}
+		if errorMessageFormat == "" {
+			fmt.Errorf("Build failed, but no message_format_on_error defined, use default")
+		} else {
+			messageFormat = errorMessageFormat
+		}
 		if errorMessageColor == "" {
 			fmt.Errorf("Build failed, but no color_on_error defined, use default")
 		} else {
@@ -111,6 +126,7 @@ func main() {
 		"from":    {fromName},
 		"message": {message},
 		"color":   {messageColor},
+		"message_format": {messageFormat}
 	}
 	valuesReader := *strings.NewReader(values.Encode())
 

--- a/step.yml
+++ b/step.yml
@@ -57,11 +57,27 @@ inputs:
         *max 15 characters*
       is_expand: true
       is_required: false
+  - message_format: html
+    opts:
+      title: Message Format
+      value_options:
+        - html
+        - text
+      is_expand: true
+      is_required: false
   - message:
     opts:
       title: "The message you want to send"
       is_expand: true
       is_required: true
+  - message_on_error_format: html
+    opts:
+      title: Message On Error Format
+      value_options:
+        - html
+        - text
+      is_expand: true
+      is_required: false
   - message_on_error:
     opts:
       title: "The message you want to send - if the build failed"

--- a/step.yml
+++ b/step.yml
@@ -59,7 +59,7 @@ inputs:
       is_required: false
   - message_format: html
     opts:
-      title: Message Format
+      title: "The message format you want to set"
       value_options:
         - html
         - text
@@ -72,7 +72,10 @@ inputs:
       is_required: true
   - message_on_error_format: html
     opts:
-      title: Message On Error Format
+      title: "The message format you want to set - if the build failed"
+      description: |
+        **This option will be used if the build failed.** If you
+        leave this option empty then the default one will be used.
       value_options:
         - html
         - text


### PR DESCRIPTION
Currently the message is sent with default message format - HTML if no option is provided while calling the API.

The HTML message format does not support @ mentions and (emojis). So enhanced to provide option for selecting message format type!!

This for my first experience with GO lang so pardon me and laugh aloud if I made a mistake. Please suggest and I will fix it.

Also was not sure how to test it.

Thanks!