### PR TITLE
Add support for notifying rooms

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,11 +28,13 @@ type ConfigsModel struct {
 	fromName string
 	message  string
 	color    string
+	notify   string
 
 	//onFail
 	fromNameOnError string
 	messageOnError  string
 	colorOnError    string
+	notifyOnError   string
 
 	//settings
 	messageFormat     string
@@ -51,10 +53,12 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		fromName: os.Getenv("from_name"),
 		message:  os.Getenv("message"),
 		color:    os.Getenv("color"),
+		notify:   os.Getenv("notify"),
 
 		fromNameOnError: os.Getenv("from_name_on_error"),
 		messageOnError:  os.Getenv("message_on_error"),
 		colorOnError:    os.Getenv("color_on_error"),
+		notifyOnError:   os.Getenv("notify_on_error"),
 
 		messageFormat:     os.Getenv("message_format"),
 		isBuildFailedMode: os.Getenv("BITRISE_BUILD_STATUS"),
@@ -70,10 +74,12 @@ func (configs ConfigsModel) print() {
 	log.Printf("- fromName: %s", configs.fromName)
 	log.Printf("- message: %s", configs.message)
 	log.Printf("- color: %s", configs.color)
+	log.Printf("- notify: %s", configs.notify)
 
 	log.Printf("- fromNameOnError: %s", configs.fromNameOnError)
 	log.Printf("- messageOnError: %s", configs.messageOnError)
 	log.Printf("- colorOnError: %s", configs.colorOnError)
+	log.Printf("- notifyOnError: %s", configs.notifyOnError)
 
 	log.Printf("- messageFormat: %s", configs.messageFormat)
 }
@@ -96,6 +102,7 @@ func main() {
 		config.fromName = config.fromNameOnError
 		config.message = config.messageOnError
 		config.color = config.colorOnError
+		config.notify = config.notifyOnError
 	}
 
 	//
@@ -110,6 +117,7 @@ func main() {
 		"message":        {config.message},
 		"color":          {config.color},
 		"message_format": {config.messageFormat},
+		"notify":         {config.notify},
 	}
 
 	valuesReader := *strings.NewReader(values.Encode())

--- a/main.go
+++ b/main.go
@@ -105,13 +105,6 @@ func main() {
 		config.notify = config.notifyOnError
 	}
 
-	// Convert notify "true", "false" to "1", "0" to match API expectation
-	if config.notify == "true" {
-		config.notify = "1"
-	} else {
-		config.notify = "0"
-	}
-
 	//
 	// Create request
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -105,6 +105,13 @@ func main() {
 		config.notify = config.notifyOnError
 	}
 
+	// Convert notify "true", "false" to "1", "0" to match API expectation
+	if config.notify == "true" {
+		config.notify = "1"
+	} else {
+		config.notify = "0"
+	}
+
 	//
 	// Create request
 	fmt.Println()

--- a/step.yml
+++ b/step.yml
@@ -65,6 +65,20 @@ inputs:
       description: |
         **This option will be used if the build failed.** If you
         leave this option empty then the default one will be used.
+  - notify: "false"
+    opts:
+      title: "Notify if the build succeeded"
+      is_required: true
+      value_options:
+        - true
+        - false
+  - notify_on_error: "true"
+    opts:
+      title: "Notify if the build failed"
+      is_required: true
+      value_options:
+        - true
+        - false
   - color: green
     opts:
       title: Message Color

--- a/step.yml
+++ b/step.yml
@@ -65,20 +65,18 @@ inputs:
       description: |
         **This option will be used if the build failed.** If you
         leave this option empty then the default one will be used.
-  - notify: "false"
+  - notify: "0"
     opts:
       title: "Notify if the build succeeded"
-      is_required: true
       value_options:
-        - true
-        - false
-  - notify_on_error: "true"
+        - "0"
+        - "1"
+  - notify_on_error: "1"
     opts:
       title: "Notify if the build failed"
-      is_required: true
       value_options:
-        - true
-        - false
+        - "0"
+        - "1"
   - color: green
     opts:
       title: Message Color


### PR DESCRIPTION
**V2 PR available here**: https://github.com/bitrise-steplib/steps-hipchat-v2/pull/3


This commit adds support for optionally notifying rooms when sending a message. 

This is useful on failures, in particular, so the room is notified with a visual (and / or audible) indicator. 

HipChat API Spec: https://www.hipchat.com/docs/apiv2/method/send_room_notification