### PR TITLE
Add ability to modify baseURL in bitrise step

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,13 +11,6 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 )
 
-// -----------------------
-// --- Constants
-// -----------------------
-const (
-	baseURL = "https://api.hipchat.com/v1"
-)
-
 // ConfigsModel ...
 type ConfigsModel struct {
 	//oAuth
@@ -37,7 +30,9 @@ type ConfigsModel struct {
 	notifyOnError   string
 
 	//settings
-	messageFormat     string
+	messageFormat string
+	baseURL       string
+
 	isBuildFailedMode string
 }
 
@@ -60,7 +55,9 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		colorOnError:    os.Getenv("color_on_error"),
 		notifyOnError:   os.Getenv("notify_on_error"),
 
-		messageFormat:     os.Getenv("message_format"),
+		messageFormat: os.Getenv("message_format"),
+		baseURL:       os.Getenv("server_url"),
+
 		isBuildFailedMode: os.Getenv("BITRISE_BUILD_STATUS"),
 	}
 }
@@ -82,6 +79,7 @@ func (configs ConfigsModel) print() {
 	log.Printf("- notifyOnError: %s", configs.notifyOnError)
 
 	log.Printf("- messageFormat: %s", configs.messageFormat)
+	log.Printf("- baseURL: %s", configs.baseURL)
 }
 
 // -----------------------
@@ -122,7 +120,7 @@ func main() {
 
 	valuesReader := *strings.NewReader(values.Encode())
 
-	url := baseURL + "/rooms/message?auth_token=" + config.token
+	url := config.baseURL + "/rooms/message?auth_token=" + config.token
 
 	request, err := http.NewRequest("POST", url, &valuesReader)
 

--- a/step.yml
+++ b/step.yml
@@ -31,7 +31,7 @@ inputs:
     opts:
       title: HipChat Auth Token
       description: |
-        This Step uses HipChat API v1, you can register a v1 API Token at [https://www.hipchat.com/admin/api](https://www.hipchat.com/admin/api).
+        This Step uses HipChat API v1, you can register a v1 API Token at [https://www.hipchat.com/admin/api](https://www.hipchat.com/admin/api) or on your own server.
       is_required: true
   - room_id:
     opts:
@@ -106,3 +106,11 @@ inputs:
      value_options:
        - html
        - text
+  - server_url: https://api.hipchat.com/v1
+    opts:
+     title: "The base url for the server to use"
+     description: |
+       **Here you can define the server url to use. For basic hipchat
+       integration, leave the default value. For enterprise
+       solutions, change this value.
+     is_required: true


### PR DESCRIPTION
Hi, I was trying to send notifications to a hipchat group, but I didn't see the option to define the server.
I have added the option, so hipchat enterprise users can now adjust the base url to make a call to their own server. Let me know if I need to change anything!